### PR TITLE
fix: propagate Slack ack to PagerDuty

### DIFF
--- a/alertmanager/alert.go
+++ b/alertmanager/alert.go
@@ -80,6 +80,30 @@ func (c *PDConfig) getTargetAlertLevels() []AlertLevel { return c.TargetAlertLev
 func (c *PDConfig) getResendDuration() time.Duration   { return c.ResendDuration }
 func (c *PDConfig) shouldSendResolveMsg() bool         { return c.ResolveMsg }
 
+// pdDedupKey builds the PagerDuty dedup key for an instance+alertEvent pair.
+// It must stay identical across trigger/acknowledge/resolve calls for the same
+// alert so they all target the same PagerDuty incident. Keying on instance
+// alone (the previous behavior) collapsed distinct alert events on the same
+// instance into one incident, so resolving one closed them all.
+func pdDedupKey(instance InstanceName, ae alertEvent) string {
+	return fmt.Sprintf("%s_%s", instance, ae)
+}
+
+// manageEvent sends a PagerDuty Events API v2 action (trigger/acknowledge/resolve)
+// for the incident identified by instance+alertEvent.
+func (c *PDConfig) manageEvent(action string, instance InstanceName, ae alertEvent, payload *pagerduty.V2Payload) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := pagerduty.ManageEventWithContext(ctx, pagerduty.V2Event{
+		RoutingKey: c.ApiKey,
+		Action:     action,
+		DedupKey:   pdDedupKey(instance, ae),
+		Payload:    payload,
+	})
+	return err
+}
+
 // notify sends alert messages to PagerDuty via API v2.
 func (c *PDConfig) notify(msg *AlertMessage) (int64, error) {
 	action := "trigger"
@@ -87,20 +111,24 @@ func (c *PDConfig) notify(msg *AlertMessage) (int64, error) {
 		action = "resolve"
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	_, err := pagerduty.ManageEventWithContext(ctx, pagerduty.V2Event{
-		RoutingKey: c.ApiKey,
-		Action:     action,
-		DedupKey:   string(msg.Instance),
-		Payload: &pagerduty.V2Payload{
-			Summary:  fmt.Sprintf("[%s] %s", msg.Instance, msg.Summary),
-			Source:   string(msg.Instance),
-			Severity: c.DefaultSeverity,
-		},
+	err := c.manageEvent(action, msg.Instance, msg.AlertEvent, &pagerduty.V2Payload{
+		Summary:  fmt.Sprintf("[%s] %s", msg.Instance, msg.Summary),
+		Source:   string(msg.Instance),
+		Severity: c.DefaultSeverity,
 	})
 	return time.Now().UnixMicro(), err
+}
+
+// acknowledge tells PagerDuty the incident for instance+alertEvent has been
+// acknowledged (e.g. via the Slack "Ack" button) without resolving it.
+func (c *PDConfig) acknowledge(instance InstanceName, ae alertEvent) error {
+	return c.manageEvent("acknowledge", instance, ae, nil)
+}
+
+// resolve tells PagerDuty the incident for instance+alertEvent has been
+// manually resolved (e.g. via the Slack "Start" button, which re-arms alerting).
+func (c *PDConfig) resolve(instance InstanceName, ae alertEvent) error {
+	return c.manageEvent("resolve", instance, ae, nil)
 }
 
 // SlackConfig holds the information needed to publish to a Slack channel for sending alerts.
@@ -164,6 +192,15 @@ func (c *SlackConfig) notify(msg *AlertMessage) (int64, error) {
 
 // buildInteractiveSlackMessage returns a Slack message block set with interactive buttons, etc.
 func buildInteractiveSlackMessage(msg *AlertMessage, mentions string) []slack.MsgOption {
+	return []slack.MsgOption{
+		slack.MsgOptionBlocks(alertMessageBlocks(msg, mentions)...),
+	}
+}
+
+// alertMessageBlocks builds the block set for an alert message. Kept separate from
+// buildInteractiveSlackMessage so alertEventFromMessageBlocks (slack.go) can be
+// tested against the exact block shape it needs to parse.
+func alertMessageBlocks(msg *AlertMessage, mentions string) []slack.Block {
 	prefix := "🔴" // Red by default
 	if msg.Status == model.AlertResolved {
 		prefix = "🟢" // Green if resolved
@@ -247,9 +284,7 @@ func buildInteractiveSlackMessage(msg *AlertMessage, mentions string) []slack.Ms
 		))
 	}
 
-	return []slack.MsgOption{
-		slack.MsgOptionBlocks(blocks...),
-	}
+	return blocks
 }
 
 // alarmName is a string that encodes the Alarmer + alertEvent

--- a/alertmanager/alert_test.go
+++ b/alertmanager/alert_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "testing"
+
+func TestPdDedupKey(t *testing.T) {
+	got := pdDedupKey(InstanceName("node-1"), alertEvent("disk-full"))
+	want := "node-1_disk-full"
+	if got != want {
+		t.Fatalf("pdDedupKey() = %q, want %q", got, want)
+	}
+}
+
+// Regression guard for the bug where PagerDuty DedupKey was derived from the
+// instance alone, causing unrelated alert events on the same instance to
+// collapse into a single incident (resolving one closed all of them).
+func TestPdDedupKey_DistinctPerAlertEvent(t *testing.T) {
+	diskFull := pdDedupKey(InstanceName("node-1"), alertEvent("disk-full"))
+	cpuHigh := pdDedupKey(InstanceName("node-1"), alertEvent("cpu-high"))
+	if diskFull == cpuHigh {
+		t.Fatalf("expected distinct dedup keys for different alert events on the same instance, both were %q", diskFull)
+	}
+}

--- a/alertmanager/main.go
+++ b/alertmanager/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 )
 
@@ -30,6 +31,13 @@ func init() {
 	err = InitializeViper()
 	if err != nil {
 		panic(err)
+	}
+
+	// `go test` links its own -test.* flags into flag.CommandLine and there's no
+	// config.toml in the repo for LoadConfig to read, so skip CLI parsing and
+	// eager config loading (which calls log.Fatalf/os.Exit on failure) under test.
+	if testing.Testing() {
+		return
 	}
 
 	flag.StringVar(&logLevel, "log-level", "", "allow showing debug log")

--- a/alertmanager/slack.go
+++ b/alertmanager/slack.go
@@ -618,7 +618,7 @@ func handleSlack(w http.ResponseWriter, r *http.Request) {
 			var (
 				msg              string
 				replacedEmoticon string
-				ae               string
+				ae               = alertEventFromMessageBlocks(blockSet)
 			)
 
 			if firstBlockAction.Text.Text == slkStartActionId {
@@ -628,14 +628,6 @@ func handleSlack(w http.ResponseWriter, r *http.Request) {
 				blockSet, _ = removeButtons(blockSet)
 				alrts, err := alertManager.writer.FindAlertRecordsByInstanceAndResolvTimestamp(agentName, nil)
 				for _, alrt := range alrts {
-					if len(blockSet) < 2 ||
-						blockSet[1].BlockType() != slack.MBTSection ||
-						len(blockSet[1].(*slack.SectionBlock).Fields) < 1 {
-						continue
-					}
-					alertBody := blockSet[1].(*slack.SectionBlock).Fields[0].Text
-					aeKey := "service: "
-					ae = alertBody[strings.Index(alertBody, aeKey)+len(aeKey) : strings.Index(alertBody, "\n")]
 					if alrt.AlertEvent == ae {
 						err = alertManager.writer.UpdateResolvTs(alrt, now)
 						break
@@ -655,6 +647,10 @@ func handleSlack(w http.ResponseWriter, r *http.Request) {
 				err = alertManager.writer.DeleteActiveAlarms(toDeleteAlrms)
 				if err != nil {
 					alertManager.logger.Error(err.Error())
+				}
+
+				if ae != "" {
+					resolvePagerDuty(agentName, ae)
 				}
 
 				agentMarks, err := alertManager.reader.FindAgentMarkByInstanceAndTime(agentName, &now)
@@ -711,6 +707,9 @@ func handleSlack(w http.ResponseWriter, r *http.Request) {
 				blockSet = removeContainingMessages(blockSet, "disabled alert until to")
 				blockSet = removeContainingMessages(blockSet, "Filter")
 
+				if ae != "" {
+					acknowledgePagerDuty(agentName, ae)
+				}
 			}
 			firstBlock.(*slack.SectionBlock).Text.Text = replaceColonToString(firstBlock.(*slack.SectionBlock).Text.Text, replacedEmoticon)
 
@@ -731,6 +730,58 @@ func handleSlack(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+}
+
+// alertEventFromMessageBlocks extracts the AlertEvent name embedded in the alert
+// message body (blockSet[1], built by alertMessageBlocks with the format
+// "service: %s\nalert: %s\n\n%s") so Slack button handlers can target the right
+// PagerDuty incident. Returns "" if it can't find a match.
+func alertEventFromMessageBlocks(blockSet []slack.Block) string {
+	if len(blockSet) < 2 || blockSet[1].BlockType() != slack.MBTSection {
+		return ""
+	}
+	section, ok := blockSet[1].(*slack.SectionBlock)
+	if !ok || section.Text == nil {
+		return ""
+	}
+
+	const serviceKey = "service: "
+	body := section.Text.Text
+	idx := strings.Index(body, serviceKey)
+	if idx < 0 {
+		return ""
+	}
+	rest := body[idx+len(serviceKey):]
+	if end := strings.Index(rest, "\n"); end >= 0 {
+		return rest[:end]
+	}
+	return rest
+}
+
+// acknowledgePagerDuty tells every enabled PagerDuty alarmer that the incident
+// for instance+alertEvent has been acknowledged from Slack.
+func acknowledgePagerDuty(instance, ae string) {
+	for _, pdConf := range alertManager.AlarmerConfig.Pagerdutys {
+		if !pdConf.Enabled {
+			continue
+		}
+		if err := pdConf.acknowledge(InstanceName(instance), alertEvent(ae)); err != nil {
+			alertManager.logger.Errorf("failed to acknowledge PagerDuty incident for %s/%s: %v", instance, ae, err)
+		}
+	}
+}
+
+// resolvePagerDuty tells every enabled PagerDuty alarmer that the incident for
+// instance+alertEvent has been manually resolved from Slack.
+func resolvePagerDuty(instance, ae string) {
+	for _, pdConf := range alertManager.AlarmerConfig.Pagerdutys {
+		if !pdConf.Enabled {
+			continue
+		}
+		if err := pdConf.resolve(InstanceName(instance), alertEvent(ae)); err != nil {
+			alertManager.logger.Errorf("failed to resolve PagerDuty incident for %s/%s: %v", instance, ae, err)
+		}
+	}
 }
 
 func extractURLWithPrefix(input string) string {

--- a/alertmanager/slack_test.go
+++ b/alertmanager/slack_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/slack-go/slack"
+)
+
+// Regression guard for the bug where the alertEvent was read from
+// blockSet[1].Fields, which is always nil for messages built by
+// alertMessageBlocks (the text lives in blockSet[1].Text instead) — so the
+// parsing loop in the Slack "Start" handler never actually matched anything.
+func TestAlertEventFromMessageBlocks_MatchesAlertMessageBlocks(t *testing.T) {
+	msg := &AlertMessage{
+		Instance:   "node-1",
+		AlertEvent: "disk-full",
+		AlertLevel: "critical",
+		Summary:    "disk usage above 90%",
+		Status:     model.AlertFiring,
+	}
+
+	blocks := alertMessageBlocks(msg, "@oncall")
+
+	got := alertEventFromMessageBlocks(blocks)
+	if got != string(msg.AlertEvent) {
+		t.Fatalf("alertEventFromMessageBlocks() = %q, want %q", got, msg.AlertEvent)
+	}
+}
+
+func TestAlertEventFromMessageBlocks_NoMatch(t *testing.T) {
+	cases := map[string][]slack.Block{
+		"empty": {},
+		"too short": {
+			slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, "*node-1*", false, false), nil, nil),
+		},
+		"wrong block type": {
+			slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, "*node-1*", false, false), nil, nil),
+			slack.NewDividerBlock(),
+		},
+		"missing service prefix": {
+			slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, "*node-1*", false, false), nil, nil),
+			slack.NewSectionBlock(slack.NewTextBlockObject(slack.MarkdownType, "no alert event here", false, false), nil, nil),
+		},
+	}
+
+	for name, blocks := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := alertEventFromMessageBlocks(blocks); got != "" {
+				t.Fatalf("alertEventFromMessageBlocks() = %q, want empty string", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Slack "Ack"/"Start" buttons now call PagerDuty acknowledge/resolve (previously no PD call existed at all — see INF-347).
- Added `PDConfig.acknowledge()`/`resolve()` using PagerDuty Events API v2's acknowledge action, and fixed the PD DedupKey to be `instance_alertEvent` instead of `instance` only, so distinct alert events on the same instance no longer collapse into one incident.
- Fixed a related dormant bug where the Slack alertEvent parser read `blockSet[1].Fields` (always nil) instead of `.Text`, so it never matched anything.
- Added a `testing.Testing()` guard in `main.go`'s `init()` so the package can run `go test` (it previously called `flag.Parse()` + eager config loading unconditionally, which is why this package had zero tests before now).

## Test plan
- [x] `go build ./...` and `go vet ./...` pass for `alertmanager`, `repository`, `util`
- [x] `go test ./...` passes (new `alert_test.go`/`slack_test.go` covering dedup-key generation and alertEvent parsing)
- [ ] Manual verification in a staging Slack/PagerDuty environment (ack a firing alert, confirm the PD incident acknowledges; use "Start" to confirm it resolves)

## Deployment note
The DedupKey format change means PD incidents already open before this deploys won't match new ack/resolve calls (their DedupKey was created with the old format) — those should be closed manually in PagerDuty during rollout.